### PR TITLE
Add SpinLock, UnsafeByteDeserializer, and refactor utilities

### DIFF
--- a/NZCore/Collections/ParallelList/UnsafeParallelList.cs
+++ b/NZCore/Collections/ParallelList/UnsafeParallelList.cs
@@ -493,6 +493,12 @@ namespace NZCore
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public ref UnsafeList<T> GetList()
+            {
+                return ref *list;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public int GetThreadIndex()
             {
                 return threadIndex;

--- a/NZCore/Components/SpinLockComponent.cs
+++ b/NZCore/Components/SpinLockComponent.cs
@@ -1,0 +1,14 @@
+// <copyright project="NZSpellCasting.SpellCaster.Data" file="SpinLockComponent.cs">
+// Copyright © 2025 Thomas Enzenebner. All rights reserved.
+// </copyright>
+
+using NZCore;
+using Unity.Entities;
+
+namespace NZSpellCasting
+{
+    public struct SpinLockComponent : IComponentData
+    {
+        public SpinLock SpinLock;
+    }
+}

--- a/NZCore/Components/SpinLockComponent.cs.meta
+++ b/NZCore/Components/SpinLockComponent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 32abb3753c5941e9a4709abfa642cd32
+timeCreated: 1744157924

--- a/NZCore/Components/SpinLockComponent.cs.rej
+++ b/NZCore/Components/SpinLockComponent.cs.rej
@@ -1,0 +1,18 @@
+--- NZCore/Components/SpinLockComponent.cs	(revision 9bf1dae6ae0c40d3a12fec8092502c0fbe47c371)
++++ NZCore/Components/SpinLockComponent.cs
+@@ -1,15 +0,0 @@
+-// <copyright project="NZSpellCasting.SpellCaster.Data" file="SpinLockComponent.cs">
+-// Copyright © 2025 Thomas Enzenebner. All rights reserved.
+-// </copyright>
+-
+-
+-using NZCore;
+-using Unity.Entities;
+-
+-namespace NZSpellCasting
+-{
+-    public struct SpinLockComponent : IComponentData
+-    {
+-        public SpinLock SpinLock;
+-    }
+-}

--- a/NZCore/Components/SpinLockComponent.cs.rej.meta
+++ b/NZCore/Components/SpinLockComponent.cs.rej.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd75415d5b72d5492a00a3c1a78a2575
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/NZCore/Entities/UnsafeComponentLookup.cs
+++ b/NZCore/Entities/UnsafeComponentLookup.cs
@@ -662,19 +662,20 @@ namespace NZCore
 
         public bool TryGetComponentPtrRW(Entity entity, out T* ptr)
         {
-            throw new NotImplementedException();
-        }
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            AtomicSafetyHandle.CheckReadAndThrow(m_Safety);
+#endif
 
-        public bool TryGetComponentRefRO<TInner>(Entity entity, out TInner* ptr)
-            where TInner : unmanaged
-        {
-            throw new NotImplementedException();
-        }
+            if (!HasComponent(entity) || m_IsZeroSized != 0)
+            {
+                ptr = null;
+                return false;
+            }
+            
 
-        public bool TryGetComponentRefRW<TInner>(Entity entity, out TInner* ptr)
-            where TInner : unmanaged
-        {
-            throw new NotImplementedException();
+            var ecs = m_Access->EntityComponentStore;
+            ptr = (T*) ecs->GetComponentDataWithTypeRW(entity, m_TypeIndex, m_GlobalSystemVersion, ref m_Cache);
+            return true;
         }
 
         public void SetChangeVersion(Entity entity)
@@ -710,6 +711,8 @@ namespace NZCore
             var chunkVersion = archetype->Chunks.GetChangeVersion(typeIndexInArchetype, chunk.ListIndex);
             return chunkVersion;
         }
+
+        public TypeIndex TypeIndex => m_TypeIndex;
 
         public static implicit operator UnsafeComponentLookup<T>(ComponentLookup<T> lookup)
         {

--- a/NZCore/Extensions/UnsafeListExtensions.cs
+++ b/NZCore/Extensions/UnsafeListExtensions.cs
@@ -111,5 +111,16 @@ namespace NZCore
                 list.RemoveAt(i);
             }
         }
+        
+        public static void AddToByteBuffer<TData>(this ref UnsafeList<byte> buffer, TData data)
+            where TData : unmanaged
+        {
+            int byteSize = UnsafeUtility.SizeOf<TData>();
+            int oldLength = buffer.Length;
+            buffer.Resize(oldLength + byteSize, NativeArrayOptions.UninitializedMemory);
+            var ptrToData = UnsafeUtility.AddressOf(ref data);
+
+            UnsafeUtility.MemCpy(buffer.Ptr + oldLength, ptrToData, byteSize);
+        }
     }
 }

--- a/NZCore/Utility/SpinLock.cs
+++ b/NZCore/Utility/SpinLock.cs
@@ -1,0 +1,74 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Unity.Collections;
+
+// publicized SpinLock from Unity.Entities
+namespace NZCore
+{
+    [GenerateTestsForBurstCompatibility]
+    public struct SpinLock
+    {
+        int m_Lock;
+
+        /// <summary>
+        /// Continually spin until the lock can be acquired.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Acquire()
+        {
+            for (;;)
+            {
+                // Optimistically assume the lock is free on the first try.
+                if (Interlocked.CompareExchange(ref m_Lock, 1, 0) == 0)
+                    return;
+
+                // Wait for lock to be released without generating cache misses.
+                while (Volatile.Read(ref m_Lock) == 1)
+                    continue;
+
+                // Future improvement: the 'continue' instruction above could be swapped for a 'pause' intrinsic
+                // instruction when the CPU supports it, to further reduce contention by reducing load-store unit
+                // utilization. However, this would need to be optional because if you don't use hyper-threading
+                // and you don't care about power efficiency, using the 'pause' instruction will slow down lock
+                // acquisition in the contended scenario.
+            }
+        }
+
+        /// <summary>
+        /// Try to acquire the lock and immediately return without spinning.
+        /// </summary>
+        /// <returns><see langword="true"/> if the lock was acquired, <see langword="false"/> otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryAcquire()
+        {
+            // First do a memory load (read) to check if lock is free in order to prevent unnecessary cache misses.
+            return Volatile.Read(ref m_Lock) == 0 &&
+                Interlocked.CompareExchange(ref m_Lock, 1, 0) == 0;
+        }
+
+        /// <summary>
+        /// Try to acquire the lock, and spin only if <paramref name="spin"/> is <see langword="true"/>.
+        /// </summary>
+        /// <param name="spin">Set to true to spin the lock.</param>
+        /// <returns><see langword="true"/> if the lock was acquired, <see langword="false"/> otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryAcquire(bool spin)
+        {
+            if (spin)
+            {
+                Acquire();
+                return true;
+            }
+            return TryAcquire();
+        }
+
+        /// <summary>
+        /// Release the lock.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Release()
+        {
+            Volatile.Write(ref m_Lock, 0);
+        }
+    }
+}

--- a/NZCore/Utility/SpinLock.cs.meta
+++ b/NZCore/Utility/SpinLock.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a8b2120edf2a47189d65cbd219d9833e
+timeCreated: 1744158024

--- a/NZCore/Utility/UnsafeByteDeserializer.cs
+++ b/NZCore/Utility/UnsafeByteDeserializer.cs
@@ -1,0 +1,84 @@
+// <copyright project="NZCore" file="ByteDeserializer.cs">
+// Copyright © 2025 Thomas Enzenebner. All rights reserved.
+// </copyright>
+
+using System;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+
+namespace NZCore
+{
+    public unsafe struct UnsafeByteDeserializer : IDisposable
+    {
+        [ReadOnly] private UnsafeList<byte> data;
+        private int currentIndex;
+
+        public int CurrentIndex => currentIndex;
+        public byte* CurrentPtr => (byte*) data.Ptr + currentIndex;
+        public bool ReachedLastIndex => currentIndex >= data.Length; // >= is safeguard for corrupt savegames to prevent endless loop
+        
+        public UnsafeByteDeserializer(UnsafeList<byte> byteList, int offset = 0)
+        {
+            data = byteList;
+            currentIndex = offset;
+        }
+
+        public ref T Read<T>()
+            where T : unmanaged
+        {
+            var ptr = (byte*)data.Ptr;
+            ref var element = ref *(T*)(ptr + currentIndex);
+            currentIndex += UnsafeUtility.SizeOf<T>();
+            return ref element;
+        }
+
+        public T* ReadRange<T>(int length)
+            where T : unmanaged
+        {
+            var ptr = (byte*)data.Ptr;
+            var ptrToData = (T*)(ptr + currentIndex);
+            currentIndex += length * UnsafeUtility.SizeOf<T>();
+            return ptrToData;
+        }
+
+        public ref T Peek<T>()
+            where T : unmanaged
+        {
+            var ptr = (byte*)data.Ptr;
+            ref var element = ref *(T*)(ptr + currentIndex);
+            return ref element;
+        }
+
+        public void AddOffset(int offset)
+        {
+            currentIndex += offset;
+        }
+
+        public void AddOffset<T>()
+            where T : unmanaged
+        {
+            currentIndex += UnsafeUtility.SizeOf<T>();
+        }
+        
+        public void AddOffsetRange<T>(int length)
+            where T : unmanaged
+        {
+            currentIndex += UnsafeUtility.SizeOf<T>() * length;
+        }
+
+        public void SetOffset(int offset)
+        {
+            currentIndex = offset;
+        }
+
+        public void Reset()
+        {
+            currentIndex = 0;
+        }
+
+        public void Dispose()
+        {
+            data.Dispose();
+        }
+    }
+}

--- a/NZCore/Utility/UnsafeByteDeserializer.cs.meta
+++ b/NZCore/Utility/UnsafeByteDeserializer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: db7db9881fbf4471895fff38864a9cd7
+timeCreated: 1744130548


### PR DESCRIPTION
- Introduced `SpinLock` struct with methods `Acquire`, `TryAcquire`, and `Release` for thread synchronization.
- Added `SpinLockComponent` as an ECS component for utilizing `SpinLock`.
- Implemented `UnsafeByteDeserializer` for efficient byte deserialization.
- Extended `UnsafeListExtensions` with `AddToByteBuffer` for byte buffer serialization.
- Slightly improved performance of `UnsafeParallelListToArraySingleThreaded`
- Enhanced `UnsafeComponentLookup` to provide `TryGetComponentPtrRW` functionality.